### PR TITLE
fixup! EAPI 7 has BDEPEND

### DIFF
--- a/dependencies.tex
+++ b/dependencies.tex
@@ -35,15 +35,17 @@ There are three classes of dependencies supported by ebuilds:
     the package manager finishes the batch of installs.
 \end{compactitem}
 
-\featurelabel{bdepend} Additionally, in EAPIs listed in table~\ref{tab:TODO-make-a-table}
+\featurelabel{bdepend} Additionally, in EAPIs listed in table~\ref{tab:bdepend-table}
 as supporting \t{BDEPEND}, the build dependencies are split into two subclasses:
 
+\begin{compactitem}
 \item Build dependencies that are binary compatible with the native build system
     / CBUILD (\t{BDEPEND}). The ebuild is allowed to call binary executables
     installed by this kind of dependency.
 \item Build dependencies that are binary compatible with the system being built
     / CHOST (\t{DEPEND}). The ebuild must not execute binary executables installed
     by this kind of dependency.
+\end{compactitem}
 
 Table~\ref{tab:phase-function-dependency-classes} lists dependencies which must be satisfied before
 a particular phase function is executed.
@@ -98,6 +100,20 @@ be surrounded on both sides by whitespace, except at the start and end of the st
 \end{compactitem}
 
 In particular, note that whitespace is not optional.
+
+\ChangeWhenAddingAnEAPI{7}
+\begin{centertable}{EAPIs supporting \t{BDEPEND}}
+    \label{tab:bdepend-table}
+    \begin{tabular}{ll}
+      \toprule
+      \multicolumn{1}{c}{\textbf{EAPI}} &
+      \multicolumn{1}{c}{\textbf{Supports \t{BDEPEND}?}} \\
+      \midrule
+      0, 1, 2, 3, 4, 5, 6 & No  \\
+      7                   & Yes \\
+      \bottomrule
+    \end{tabular}
+\end{centertable}
 
 \ChangeWhenAddingAnEAPI{7}
 \begin{centertable}{EAPIs supporting \t{SRC_URI} arrows}

--- a/dependencies.tex
+++ b/dependencies.tex
@@ -23,25 +23,27 @@
     \end{tabular}
 \end{centertable}
 
-There are four classes of dependencies supported by ebuilds:
+There are three classes of dependencies supported by ebuilds:
 
 \begin{compactitem}
-\item \featurelabel{bdepend} Build dependencies that are binary compatible
-    with the native build system / CBUILD (\t{BDEPEND}). The ebuild is allowed
-    to execute binary executables installed by this kind of dependency. These must
-    be installed and usable before any of the ebuild \t{src_*} phase functions are
-    executed. These may not be installed at all if a binary package is being
-    merged.
-\item Build dependencies that are binary compatible with the system being built
-    / CHOST (\t{DEPEND}). The ebuild must not execute binary executables installed
-    by this kind of dependency. These must be installed and usable before any of
-    the ebuild \t{src_*} phase functions are executed. These may not be installed
-    at all if a binary package is being merged.
+\item Build dependencies (\t{DEPEND}). These must be installed and usable before any of
+    the ebuild \t{src_*} phase functions is executed. These may not be installed at all
+    if a binary package is being merged.
 \item Runtime dependencies (\t{RDEPEND}). These must be installed and usable before
     the results of an ebuild merging are treated as usable.
 \item Post dependencies (\t{PDEPEND}). These must be installed at some point before
     the package manager finishes the batch of installs.
 \end{compactitem}
+
+\featurelabel{bdepend} Additionally, in EAPIs listed in table~\ref{tab:TODO-make-a-table}
+as supporting \t{BDEPEND}, the build dependencies are split into two subclasses:
+
+\item Build dependencies that are binary compatible with the native build system
+    / CBUILD (\t{BDEPEND}). The ebuild is allowed to call binary executables
+    installed by this kind of dependency.
+\item Build dependencies that are binary compatible with the system being built
+    / CHOST (\t{DEPEND}). The ebuild must not execute binary executables installed
+    by this kind of dependency.
 
 Table~\ref{tab:phase-function-dependency-classes} lists dependencies which must be satisfied before
 a particular phase function is executed.

--- a/dependencies.tex
+++ b/dependencies.tex
@@ -23,6 +23,21 @@
     \end{tabular}
 \end{centertable}
 
+\begin{centertable}{Summary of other interfaces related to dependency classes}
+    \label{tab:dependency-class-apis}
+    \begin{tabular}{l c c c}
+      \toprule
+      & \t{BDEPEND} & \t{DEPEND} & \t{RDEPEND}, \t{PDEPEND} \\
+      \midrule
+      binary compatible with & \t{CBUILD} & \t{CHOST} & \t{CHOST} \\
+      base unprefixed path & \t{/} & \t{\$\{SYSROOT\}} & \t{\$\{ROOT\}} \\
+      relevant offset-prefix & \t{\$\{BROOT\}} & \t{\$\{EPREFIX\}} & \t{\$\{EPREFIX\}} \\
+      path combined with prefix & \t{\$\{BROOT\}} & \t{\$\{ESYSROOT\}} & \t{\$\{EROOT\}} \\
+      \featurelabel{pm-query-options}\t{has_version} query option & \t{-b} & \t{-d} & \t{-r} \\
+      \bottomrule
+    \end{tabular}
+\end{centertable}
+
 There are three classes of dependencies supported by ebuilds:
 
 \begin{compactitem}
@@ -48,7 +63,8 @@ as supporting \t{BDEPEND}, the build dependencies are split into two subclasses:
 \end{compactitem}
 
 Table~\ref{tab:phase-function-dependency-classes} lists dependencies which must be satisfied before
-a particular phase function is executed.
+a particular phase function is executed. Table~\ref{tab:dependency-class-api} summarizes
+additional interfaces related to the dependency classes.
 
 In addition, \t{SRC_URI}, \t{HOMEPAGE}, \t{RESTRICT}, \t{PROPERTIES}, \t{LICENSE} and
 \t{REQUIRED_USE} use dependency-style specifications to specify their values.


### PR DESCRIPTION
Let's split this into main classes and subclasses for EAPIs supporting
BDEPEND. The idea is that there are two different criteria for them --
DEPEND/RDEPEND/PDEPEND is mostly about 'when it is installed'.
BDEPEND/DEPEND is more about 'what is installed and where'.